### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://codedev.ms/v-wexu1/9ac995cd-8bfa-441e-b6c8-bbdf126d5f5a/7b29c480-41dd-48f7-8f2d-81d896f7f752/_apis/work/boardbadge/65edb67e-4f12-4daa-8772-50849e47d4e6)](https://codedev.ms/v-wexu1/9ac995cd-8bfa-441e-b6c8-bbdf126d5f5a/_boards/board/t/7b29c480-41dd-48f7-8f2d-81d896f7f752/Microsoft.RequirementCategory)
 # A1
 1-2
 121


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://codedev.ms/v-wexu1/9ac995cd-8bfa-441e-b6c8-bbdf126d5f5a/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.